### PR TITLE
Allow None value as chunk_size

### DIFF
--- a/chunkator/__init__.py
+++ b/chunkator/__init__.py
@@ -53,7 +53,7 @@ def chunkator_page(source_qs, chunk_size, query_log=None):
 
         yield page
 
-        if nb_items < chunk_size:
+        if nb_items < chunk_size or chunk_size is None:
             return
 
 


### PR DESCRIPTION
Allowing `None` value to `chunk_size` makes it equivalent to iterating over the whole dataset.